### PR TITLE
fix: add files field in package.json to include lib folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 ### Security
 -->
 
+## 1.0.2
+### Fixed
+- Include the lib folder build when publish package in npm registry.
+
 ## 1.0.1
 ### Fixed
 - Correct typo errors on command description in the readme file of the project

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-module-cloner",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A CLI tool to clone and rename NestJS modules, dependencies and content from an existing to a new resource",
   "author": "LeDevNovice",
   "license": "MIT",
@@ -59,5 +59,8 @@
       "ts",
       "js"
     ]
-  }
+  },
+  "files": [
+    "lib/**/*"
+  ]
 }


### PR DESCRIPTION
## Description

_The build of the program doesn't included the lib folder build and then when installing the package there was an error that specify that the bin file doesn't found the lib folder to execute the logic._

Type of change:

<!-- Please select one. -->

- 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code (if relevant, particularly in _hard-to-understand_ areas)
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if relevant)
- [ ] I have made corresponding changes to the documentation or `README.md` (if relevant)
- [X] I have updated the `CHANGELOG.md` file (if relevant)

